### PR TITLE
Implementing contains(ray, point) function

### DIFF
--- a/olcUTIL_Geometry2D.h
+++ b/olcUTIL_Geometry2D.h
@@ -1091,8 +1091,6 @@ namespace olc::utils::geom2d
 		return distance < epsilon;
 	}
 
-
-
 	// overlaps(p,p)
 	// Check if point overlaps with point (analogous to contains())
 	template<typename T1, typename T2>

--- a/olcUTIL_Geometry2D.h
+++ b/olcUTIL_Geometry2D.h
@@ -172,7 +172,7 @@
              | intersects   | intersects   | intersects   | intersects   | intersects   |              |
              |              |              |              |              |              |              |
     ---------+--------------+--------------+--------------+--------------+--------------+--------------+
-    RAY      |              |              |              |              |              |              |
+    RAY      | contains     |              |              |              |              |              |
              |              |              |              |              |              |              |
              |              | collision    | collision    | collision    | collision    | collision*   |
              |              | intersects   | intersects   | intersects   | intersects   | intersects   |
@@ -1064,10 +1064,37 @@ namespace olc::utils::geom2d
 		return s >= T2(0) && v >= T2(0) && (s + v) <= T2(2) * A * sign;
 	}
 
+	template<typename T1, typename T2>
+	inline constexpr bool contains(const ray<T1>& r, const olc::v_2d<T2>& p)
+	{
+		// Calculate the vector from the ray's origin to point p
+		olc::v_2d<T2> op = p - r.origin;
+
+		// Calculate the dot product between op and the ray's direction
+		// This checks if p is in the direction of the ray and not behind the origin
+		T2 dotProduct = op.dot(r.direction);
+
+		if (dotProduct < 0) {
+			// p is behind the ray's origin
+			return false;
+		}
+
+		// Project op onto the ray's direction (which is already normalized)
+		olc::v_2d<T2> projection = { r.direction.x * dotProduct, r.direction.y * dotProduct };
+
+		// Check if the projection of op onto the ray's direction is equivalent to op
+		// This is true if p lies on the ray
+
+		T2 distance = std::sqrt((projection.x - op.x) * (projection.x - op.x) + (projection.y - op.y) * (projection.y - op.y));
+
+		// Assuming a small threshold for floating point arithmetic issues
+		return distance < epsilon;
+	}
+
 
 
 	// overlaps(p,p)
-	// Check if point overlaps with point (analagous to contains())
+	// Check if point overlaps with point (analogous to contains())
 	template<typename T1, typename T2>
 	inline constexpr bool overlaps(const olc::v_2d<T1>& p1, const olc::v_2d<T2>& p2)
 	{


### PR DESCRIPTION
## SUMMARY

This PR contains an implementation of the contains() function for rays and points. It tests whether the given point lies on the ray. It first checks if the point is behind the ray. It then uses the library defined epsilon value to test if the point is on the ray. I added comments to the function to make it clear what the code is doing for other readers. Also fixed a small typo in a comment below my function and added my function to the function matrix comment.