### PR TITLE
Added implementation for closest(ray, point)

### DIFF
--- a/TEST_Geometry2D.cpp
+++ b/TEST_Geometry2D.cpp
@@ -377,6 +377,13 @@ public:
 
 		// Laser beam		
 		ray<float> ray_laser{ {10.0f, 300.0f}, {1.0f, 0.0f} };
+
+		// Display a light-blue point for testing the closest-function between the ray ray_laser and 
+		// the point mouse_position
+		olc::vf2d mouse_position = GetMousePos();
+		auto closest_between_ray_and_point = closest(ray_laser, mouse_position);
+		olc::PixelGameEngine::FillCircle(closest_between_ray_and_point, 2, olc::Pixel(50, 200, 255));
+
 		bool ray_stop = false;
 		int nBounces = 100;
 		size_t last_hit_index = -1;


### PR DESCRIPTION
As the title states, I added an implementation for one of the missing `closest`-functions. I also added a few lines in the TEST app to show the function working between the red ray `ray_laser` and the point `mouse_position`. The closest point is shown in light-blue on the ray.

This is my first contribution to an open-source project and I also do not work with c++ often, so suggestions and critique is welcome.