### PR TITLE
Added implementation for closest(circle, circle)

### DIFF
--- a/olcUTIL_Geometry2D.h
+++ b/olcUTIL_Geometry2D.h
@@ -952,8 +952,7 @@ namespace olc::utils::geom2d
 	template<typename T1, typename T2>
 	inline olc::v_2d<T1> closest(const circle<T1>& c1, const circle<T2>& c2)
 	{
-		const auto dirVec = c2.pos - c1.pos;
-		return c1.pos + c1.radius * dirVec.norm();
+		return closest(c1, c2.pos);
 	}
 
 	// closest(t,c)

--- a/olcUTIL_Geometry2D.h
+++ b/olcUTIL_Geometry2D.h
@@ -950,10 +950,10 @@ namespace olc::utils::geom2d
 	// closest(c,c)
 	// Returns closest point on circle to circle
 	template<typename T1, typename T2>
-	inline olc::v_2d<T1> closest(const circle<T1>& c, const circle<T2>& l)
+	inline olc::v_2d<T1> closest(const circle<T1>& c1, const circle<T2>& c2)
 	{
-		// TODO:
-		return {};
+		const auto dirVec = c2.pos - c1.pos;
+		return c1.pos + c1.radius * dirVec.norm();
 	}
 
 	// closest(t,c)


### PR DESCRIPTION
This PR contains the implementation for the `closest(circle, circle)` function.

The implementation applies the following formula:
> Note: $\vec{A} = \left(A_x, B_x\right)$

$$
\vec{C} = \vec{A} + r\frac{\left(\vec{B}-\vec{A}\right)}{\lVert \vec{B}-\vec{A} \rVert}.
$$

Given `closest(c1, c2)`, this implementation returns the point on c1 which is closest to the origin of c2.

This is my first attempt at contributing to an open source project. I'd appreciate any advice/criticism.

