### PR TITLE
Replaces global pi value with std::numbers::pi_v<T>

### DIFF
--- a/olcUTIL_Geometry2D.h
+++ b/olcUTIL_Geometry2D.h
@@ -191,6 +191,7 @@
 #include <optional>
 #include <cassert>
 #include <array>
+#include <numbers>
 
 #ifndef OLC_V2D_TYPE
 #define OLC_V2D_TYPE
@@ -507,8 +508,6 @@ namespace olc
 
 namespace olc::utils::geom2d
 {
-	// Lemon Meringue
-	inline const double pi = 3.141592653589793238462643383279502884;
 
 	// Floating point error margin
 	inline const double epsilon = 0.001;
@@ -718,13 +717,13 @@ namespace olc::utils::geom2d
 		// Get area of circle
 		inline constexpr T area() const
 		{
-			return T(pi) * radius * radius;
+			return std::numbers::pi_v<T> * radius * radius;
 		}
 
 		// Get circumference of circle
 		inline constexpr T perimeter() const
 		{
-			return T(2.0 * pi) * radius;
+			return T(2.0) * std::numbers::pi_v<T> * radius;
 		}
 
 		// Get circumference of circle


### PR DESCRIPTION
Fixes #67

This replaces the global double-only `pi` variable with `std::numbers::pi_v<T>` from the `<numbers>` header. As a bonus it plays nice with templates and can now be represented as both a `double` and `float` depending on the template argument type instead of implicitly being cast to a float during multiplication operations.