### PR TITLE
add enforcement for include order of PixelGameEngine header

### DIFF
--- a/olcUTIL_Geometry2D.h
+++ b/olcUTIL_Geometry2D.h
@@ -192,6 +192,15 @@
 #include <cassert>
 #include <array>
 
+
+#ifdef PGE_VER
+#error "olcUTIL_Geometry2D.h must be included BEFORE olcPixelGameEngine.h"
+#else
+
+#ifndef OLC_IGNORE_VEC2D
+#define OLC_IGNORE_VEC2D
+#endif
+
 #ifndef OLC_V2D_TYPE
 #define OLC_V2D_TYPE
 namespace olc
@@ -2493,3 +2502,5 @@ namespace olc::utils::geom2d
 		return internal::filter_duplicate_points(intersections);
 	}
 }
+
+#endif // PGE_VER


### PR DESCRIPTION
Checks if PGE was included and if so, throws an error at compile time letting the programmer know that this library needs to be include before PGE is include.

Also, shifting the ``OLC_IGNORE_VEC2D`` macro definition to inside the header so the programmer needn't do it manually at every inclusion of the header.
